### PR TITLE
Option to use templates for templates in the vhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0 (2016-07-07)
+
+Features:
+  - Add option to work with templates in the vhost.    
+
 ## 0.1.0 (May 22, 2016)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ nginx::resource::vhost { 'example.com':
 
 ##### Parameters
 
-* **source** a file in a puppet module.
-* **content** Content of the vhost file.
+* **source** a file in a puppet module. It is not possible to combine this option with content.
+* **content** Content of the vhost file. It is not possible to combine this option with source.
 * **enabled** Creates a link under `/etc/nginx/sites-enabled`.
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -144,9 +144,18 @@ nginx::resource::vhost { 'example.com':
 }
 ```
 
+or with a template:
+```puppet
+nginx::resource::vhost { 'example.com':
+  enabled => true
+  content => template('webproxy/example.erb'),
+}
+```
+
 ##### Parameters
 
 * **source** a file in a puppet module.
+* **content** Content of the vhost file.
 * **enabled** Creates a link under `/etc/nginx/sites-enabled`.
 
 ## Dependencies

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -1,8 +1,23 @@
 define nginx::resource::vhost (
-  String                      $source,
+  String                      $source  = '',
+  String                      $content = '',
   Enum[ 'present', 'absent' ] $ensure  = present,
   Boolean                     $enabled = true,
 ) {
+
+  if (empty($source)) and (empty($content)) {
+    fail('Please provide source or content')
+  }
+
+  $file_source = $source ? {
+    ''      => undef,
+    default => $source,
+  }
+
+  $file_content = $content ? {
+    '' => undef,
+    default => $content,
+  }
 
   $install_location = $::nginx::install_location
   $sites_available  = "${install_location}/sites-available"
@@ -31,7 +46,8 @@ define nginx::resource::vhost (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    source  => $source,
+    source  => $file_source,
+    content => $file_content,
     require => File[$sites_enabled],
     notify  => Class["${module_name}::service"],
   }

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -8,6 +8,9 @@ define nginx::resource::vhost (
   if (empty($source)) and (empty($content)) {
     fail('Please provide source or content')
   }
+  elsif (!empty($source)) and (!empty($content)) {
+    fail('Please provide source or content, the options are mutually exclusive')
+  }
 
   $file_source = $source ? {
     ''      => undef,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "rehan-nginx",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Rehan Mahmood",
   "summary": "A Puppet module to install, configure and deploy the latest Nginx webserver from stable or mainline.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Is it possible to add an option to the vhost to use a template file? 

something like this would be great:

$domain = 'test.com'
nginx::resource::vhost { $domain:
  enabled => true,
  content  => template('module/nginx/proxyvhost.erb'),
}

With the content of module/nginx/proxyvhost.erb:
server {
  listen 80;

  server_name <%= @domain %>;

  location / {
    proxy_pass http://localhost:5601;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection 'upgrade';
    proxy_set_header Host $host;
    proxy_cache_bypass $http_upgrade;
  }
}

I will create a pull request if I can find some time to do this.