### PR TITLE
RFC: allow to set nginx.conf template via class parameter refs: #31

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,14 +1,19 @@
-class nginx::config () inherits nginx {
+class nginx::config (
+  String $template = "${module_name}/nginx.conf.epp",
+  Hash $template_parameters = {},
+) inherits nginx {
 
   assert_private("Use of private class ${name} by ${caller_module_name}")
 
+  $default_template_parameters = {
+    'install_location' => $nginx::install_location,
+  }
+
+  $_template_parameters = $default_template_parameters + $template_parameters
+
   file { "${nginx::install_location}/nginx.conf":
     ensure  => file,
-    content => epp("${module_name}/nginx.conf.epp",
-      {
-        'install_location' => $nginx::install_location,
-      }
-    ),
+    content => epp($template, $_template_parameters),
   }
   -> file { "${nginx::install_location}/sites-available":
     ensure  => directory,


### PR DESCRIPTION
this could be a solution to #31

config could be set via hiera like this:
```
nginx::config::template: profile/nginx/nginx.conf.epp
nginx::config::template_parameters:
  nginx_user: www-data
```

edit: change of the manifest file is only for me and can/should be reverted before the merge